### PR TITLE
Support WS2813.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Also now supports the [RedBear Duo](https://github.com/redbear/Duo).
 Implementation based on Adafruit's NeoPixel Library.
 
 ## Supported Pixel Types
-- 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+- 800 KHz and 400kHz bitstream WS2813, WS2812, WS2812B and WS2811
 - 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
   - (use 'SK6812RGBW' as `PIXEL_TYPE`)
 
@@ -64,9 +64,9 @@ _Note: for some stripes like those with the TM1829, you need to count the number
 
 `PIXEL_PIN` is the pin number where your NeoPixel are connected (A0-A7, D0-D7, etc). Most pins are valid. If omitted, D2 is used.
 
-`PIXEL_TYPE` is the type of LED, one of WS2812, WS2812B, WS2812B2, WS2811, TM1803, TM1829, SK6812RGBW. If omitted, WS2812B is used.
+`PIXEL_TYPE` is the type of LED, one of WS2813, WS2812, WS2812B, WS2812B2, WS2811, TM1803, TM1829, SK6812RGBW. If omitted, WS2812B is used.
 
-_Note: RGB order is automatically applied to WS2811, WS2812/WS2812B/WS2812B2/TM1803 is GRB order._
+_Note: RGB order is automatically applied to WS2811, WS2812/WS2812B/WS2812B2/WS2813/TM1803 is GRB order._
 
 ### `begin`
 

--- a/src/neopixel.cpp
+++ b/src/neopixel.cpp
@@ -3,7 +3,7 @@
   WS2811/WS2812 based RGB LED devices such as Adafruit NeoPixel strips.
 
   Supports:
-  - 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+  - 800 KHz and 400kHz bitstream WS2813, WS2812, WS2812B and WS2811
   - 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
     (use 'SK6812RGBW' as PIXEL_TYPE)
 
@@ -128,6 +128,9 @@ void Adafruit_NeoPixel::show(void) {
     case TM1829: { // TM1829 = 500us reset pulse
         wait_time = 500L;
       } break;
+    case WS2813: { // WS2813 = 300us reset pulse
+        wait_time = 300L;
+      } break;
     case WS2812B: // WS2812 & WS2812B = 50us reset pulse
     case WS2812B2:
     case WS2811: // WS2811 = 50us reset pulse
@@ -154,7 +157,7 @@ void Adafruit_NeoPixel::show(void) {
     b,              // Current blue byte value
     w;              // Current white byte value
 
-  if(type == WS2812B) { // same as WS2812, 800 KHz bitstream
+  if(type == WS2812B || type == WS2813) { // same as WS2812, 800 KHz bitstream
     while(i) { // While bytes left... (3 bytes = 1 pixel)
       mask = 0x800000; // reset the mask
       i = i-3;      // decrement bytes remaining
@@ -800,6 +803,7 @@ void Adafruit_NeoPixel::setPixelColor(
     switch(type) {
       case WS2812B: // WS2812 & WS2812B is GRB order.
       case WS2812B2:
+      case WS2813:  // WS2813 is GRB order.
         *p++ = g;
         *p++ = r;
         *p = b;
@@ -835,6 +839,7 @@ void Adafruit_NeoPixel::setPixelColor(
     switch(type) {
       case WS2812B: // WS2812 & WS2812B is GRB order.
       case WS2812B2:
+      case WS2813:  // WS2813 is GRB order.
         *p++ = g;
         *p++ = r;
         *p = b;
@@ -878,7 +883,8 @@ void Adafruit_NeoPixel::setPixelColor(uint16_t n, uint32_t c) {
     uint8_t *p = &pixels[n * (type==SK6812RGBW?4:3)];
     switch(type) {
       case WS2812B: // WS2812 & WS2812B is GRB order.
-      case WS2812B2: {
+      case WS2812B2:
+      case WS2813: { // WS2813 is GRB order.
           *p++ = g;
           *p++ = r;
           *p = b;
@@ -966,7 +972,8 @@ uint32_t Adafruit_NeoPixel::getPixelColor(uint16_t n) const {
 
   switch(type) {
     case WS2812B: // WS2812 & WS2812B is GRB order.
-    case WS2812B2: {
+    case WS2812B2:
+    case WS2813: { // WS2813 is GRB order.
         c = ((uint32_t)p[1] << 16) | ((uint32_t)p[0] <<  8) | (uint32_t)p[2];
       }
       break;

--- a/src/neopixel.h
+++ b/src/neopixel.h
@@ -3,7 +3,7 @@
   WS2811/WS2812 based RGB LED devices such as Adafruit NeoPixel strips.
 
   Supports:
-  - 800 KHz and 400kHz bitstream WS2812, WS2812B and WS2811
+  - 800 KHz and 400kHz bitstream WS2813, WS2812, WS2812B and WS2811
   - 800 KHz bitstream SK6812RGBW (NeoPixel RGBW pixel strips)
     (use 'SK6812RGBW' as PIXEL_TYPE)
 
@@ -63,6 +63,7 @@
 #define TM1829   0x04 // 800 KHz datastream ()
 #define WS2812B2 0x05 // 800 KHz datastream (NeoPixel)
 #define SK6812RGBW 0x06 // 800 KHz datastream (NeoPixel RGBW)
+#define WS2813   0x07 // 800 KHz datastream (NeoPixel)
 
 class Adafruit_NeoPixel {
 
@@ -71,7 +72,7 @@ class Adafruit_NeoPixel {
   // Constructor: number of LEDs, pin number, LED type
   Adafruit_NeoPixel(uint16_t n, uint8_t p=2, uint8_t t=WS2812B);
   ~Adafruit_NeoPixel();
-  
+
   void
     begin(void),
     show(void) __attribute__((optimize("Ofast"))),


### PR DESCRIPTION
WS2813 protocol requires a longer reset interval than WS2812B.  Some online sources claim 250 us but datasheet says 300 us so that's what we use here.