### PR TITLE
Adding Support for Xenon, Argon and Boron

### DIFF
--- a/src/neopixel.cpp
+++ b/src/neopixel.cpp
@@ -59,6 +59,13 @@
   STM32_Pin_Info* PIN_MAP2 = HAL_Pin_Map(); // Pointer required for highest access speed
   #define pinLO(_pin) (PIN_MAP2[_pin].gpio_peripheral->BSRRH = PIN_MAP2[_pin].gpio_pin)
   #define pinHI(_pin) (PIN_MAP2[_pin].gpio_peripheral->BSRRL = PIN_MAP2[_pin].gpio_pin)
+#elif (PLATFORM_ID == 12) || (PLATFORM_ID == 13) || (PLATFORM_ID == 14) // Argon (12), Boron (13), Xenon (14)
+  #include "nrf.h"
+  #include "nrf_gpio.h"
+  #include "pinmap_impl.h"
+  NRF5x_Pin_Info* PIN_MAP2 = HAL_Pin_Map();
+  #define pinLO(_pin) (nrf_gpio_pin_clear(NRF_GPIO_PIN_MAP(PIN_MAP2[_pin].gpio_port, PIN_MAP2[_pin].gpio_pin)))
+  #define pinHI(_pin) (nrf_gpio_pin_set(NRF_GPIO_PIN_MAP(PIN_MAP2[_pin].gpio_port, PIN_MAP2[_pin].gpio_pin)))
 #else
   #error "*** PLATFORM_ID not supported by this library. PLATFORM should be Core, Photon, P1, Electron or RedBear Duo ***"
 #endif
@@ -144,6 +151,7 @@ void Adafruit_NeoPixel::show(void) {
   // instances on different pins can be quickly issued in succession (each
   // instance doesn't delay the next).
 
+#if (PLATFORM_ID == 0) || (PLATFORM_ID == 6) || (PLATFORM_ID == 8) || (PLATFORM_ID == 10) || (PLATFORM_ID == 88) // Core (0), Photon (6), P1 (8), Electron (10) or Redbear Duo (88)
   __disable_irq(); // Need 100% focus on instruction timing
 
   volatile uint32_t
@@ -788,6 +796,293 @@ void Adafruit_NeoPixel::show(void) {
   }
 
   __enable_irq();
+#elif (PLATFORM_ID == 12) || (PLATFORM_ID == 13) || (PLATFORM_ID == 14) // Argon (12), Boron (13), Xenon (14)
+// [[[Begin of the Neopixel NRF52 EasyDMA implementation
+//                                    by the Hackerspace San Salvador]]]
+// This technique uses the PWM peripheral on the NRF52. The PWM uses the
+// EasyDMA feature included on the chip. This technique loads the duty 
+// cycle configuration for each cycle when the PWM is enabled. For this 
+// to work we need to store a 16 bit configuration for each bit of the
+// RGB(W) values in the pixel buffer.
+// Comparator values for the PWM were hand picked and are guaranteed to
+// be 100% organic to preserve freshness and high accuracy. Current 
+// parameters are:
+//   * PWM Clock: 16Mhz
+//   * Minimum step time: 62.5ns
+//   * Time for zero in high (T0H): 0.31ms
+//   * Time for one in high (T1H): 0.75ms
+//   * Cycle time:  1.25us
+//   * Frequency: 800Khz
+// For 400Khz we just double the calculated times.
+// ---------- BEGIN Constants for the EasyDMA implementation -----------
+// The PWM starts the duty cycle in LOW. To start with HIGH we
+// need to set the 15th bit on each register.
+
+// WS2812 (rev A) timing is 0.35 and 0.7us
+//#define MAGIC_T0H               5UL | (0x8000) // 0.3125us
+//#define MAGIC_T1H              12UL | (0x8000) // 0.75us
+
+// WS2812B (rev B) timing is 0.4 and 0.8 us
+#define MAGIC_T0H               6UL | (0x8000) // 0.375us
+#define MAGIC_T1H              13UL | (0x8000) // 0.8125us
+
+// WS2811 (400 khz) timing is 0.5 and 1.2
+#define MAGIC_T0H_400KHz        8UL  | (0x8000) // 0.5us
+#define MAGIC_T1H_400KHz        19UL | (0x8000) // 1.1875us
+
+// For 400Khz, we double value of CTOPVAL
+#define CTOPVAL                20UL            // 1.25us
+#define CTOPVAL_400KHz         40UL            // 2.5us
+
+// ---------- END Constants for the EasyDMA implementation -------------
+// 
+// If there is no device available an alternative cycle-counter
+// implementation is tried.
+// The nRF52832 runs with a fixed clock of 64Mhz. The alternative
+// implementation is the same as the one used for the Teensy 3.0/1/2 but
+// with the Nordic SDK HAL & registers syntax.
+// The number of cycles was hand picked and is guaranteed to be 100% 
+// organic to preserve freshness and high accuracy.
+// ---------- BEGIN Constants for cycle counter implementation ---------
+#define CYCLES_800_T0H  18  // ~0.36 uS
+#define CYCLES_800_T1H  41  // ~0.76 uS
+#define CYCLES_800      71  // ~1.25 uS
+
+#define CYCLES_400_T0H  26  // ~0.50 uS
+#define CYCLES_400_T1H  70  // ~1.26 uS
+#define CYCLES_400      156 // ~2.50 uS
+// ---------- END of Constants for cycle counter implementation --------
+
+  // To support both the SoftDevice + Neopixels we use the EasyDMA
+  // feature from the NRF25. However this technique implies to
+  // generate a pattern and store it on the memory. The actual
+  // memory used in bytes corresponds to the following formula:
+  //              totalMem = numBytes*8*2+(2*2)
+  // The two additional bytes at the end are needed to reset the
+  // sequence.
+  //
+  // If there is not enough memory, we will fall back to cycle counter
+  // using DWT
+  uint32_t  pattern_size   = numBytes*8*sizeof(uint16_t)+2*sizeof(uint16_t);
+  uint16_t* pixels_pattern = NULL;
+
+  NRF_PWM_Type* pwm = NULL;
+
+  // Try to find a free PWM device, which is not enabled
+  // and has no connected pins
+  NRF_PWM_Type* PWM[3] = {NRF_PWM0, NRF_PWM1, NRF_PWM2};
+  for(int device = 0; device<3; device++) {
+    if( (PWM[device]->ENABLE == 0)                            &&
+        (PWM[device]->PSEL.OUT[0] & PWM_PSEL_OUT_CONNECT_Msk) &&
+        (PWM[device]->PSEL.OUT[1] & PWM_PSEL_OUT_CONNECT_Msk) &&
+        (PWM[device]->PSEL.OUT[2] & PWM_PSEL_OUT_CONNECT_Msk) &&
+        (PWM[device]->PSEL.OUT[3] & PWM_PSEL_OUT_CONNECT_Msk)
+    ) {
+      pwm = PWM[device];
+      break;
+    }
+  }
+  
+  // only malloc if there is PWM device available
+  if ( pwm != NULL ) {
+    #ifdef ARDUINO_FEATHER52 // use thread-safe malloc
+      pixels_pattern = (uint16_t *) rtos_malloc(pattern_size);
+    #else
+      pixels_pattern = (uint16_t *) malloc(pattern_size);
+    #endif
+  }
+
+  // Use the identified device to choose the implementation
+  // If a PWM device is available use DMA
+  if( (pixels_pattern != NULL) && (pwm != NULL) ) {
+    uint16_t pos = 0; // bit position
+
+    for(uint16_t n=0; n<numBytes; n++) {
+      uint8_t pix = pixels[n];
+
+      for(uint8_t mask=0x80, i=0; mask>0; mask >>= 1, i++) {
+        #ifdef NEO_KHZ400
+        if( !is800KHz ) {
+          pixels_pattern[pos] = (pix & mask) ? MAGIC_T1H_400KHz : MAGIC_T0H_400KHz;
+        }else
+        #endif
+        {
+          pixels_pattern[pos] = (pix & mask) ? MAGIC_T1H : MAGIC_T0H;
+        }
+
+        pos++;
+      }
+    }
+
+    // Zero padding to indicate the end of que sequence
+    pixels_pattern[++pos] = 0 | (0x8000); // Seq end
+    pixels_pattern[++pos] = 0 | (0x8000); // Seq end
+
+    // Set the wave mode to count UP
+    pwm->MODE = (PWM_MODE_UPDOWN_Up << PWM_MODE_UPDOWN_Pos);
+
+    // Set the PWM to use the 16MHz clock
+    pwm->PRESCALER = (PWM_PRESCALER_PRESCALER_DIV_1 << PWM_PRESCALER_PRESCALER_Pos);
+
+    // Setting of the maximum count
+    // but keeping it on 16Mhz allows for more granularity just
+    // in case someone wants to do more fine-tuning of the timing.
+#ifdef NEO_KHZ400
+    if( !is800KHz ) {
+      pwm->COUNTERTOP = (CTOPVAL_400KHz << PWM_COUNTERTOP_COUNTERTOP_Pos);
+    }else
+#endif
+    {
+      pwm->COUNTERTOP = (CTOPVAL << PWM_COUNTERTOP_COUNTERTOP_Pos);
+    }
+
+    // Disable loops, we want the sequence to repeat only once
+    pwm->LOOP = (PWM_LOOP_CNT_Disabled << PWM_LOOP_CNT_Pos);
+
+    // On the "Common" setting the PWM uses the same pattern for the
+    // for supported sequences. The pattern is stored on half-word
+    // of 16bits
+    pwm->DECODER = (PWM_DECODER_LOAD_Common << PWM_DECODER_LOAD_Pos) |
+                   (PWM_DECODER_MODE_RefreshCount << PWM_DECODER_MODE_Pos);
+
+    // Pointer to the memory storing the patter
+    pwm->SEQ[0].PTR = (uint32_t)(pixels_pattern) << PWM_SEQ_PTR_PTR_Pos;
+
+    // Calculation of the number of steps loaded from memory.
+    pwm->SEQ[0].CNT = (pattern_size/sizeof(uint16_t)) << PWM_SEQ_CNT_CNT_Pos;
+
+    // The following settings are ignored with the current config.
+    pwm->SEQ[0].REFRESH  = 0;
+    pwm->SEQ[0].ENDDELAY = 0;
+
+    // The Neopixel implementation is a blocking algorithm. DMA
+    // allows for non-blocking operation. To "simulate" a blocking
+    // operation we enable the interruption for the end of sequence
+    // and block the execution thread until the event flag is set by
+    // the peripheral.
+//    pwm->INTEN |= (PWM_INTEN_SEQEND0_Enabled<<PWM_INTEN_SEQEND0_Pos);
+
+    // PSEL must be configured before enabling PWM
+    pwm->PSEL.OUT[0] = NRF_GPIO_PIN_MAP(PIN_MAP2[pin].gpio_port, PIN_MAP2[pin].gpio_pin);
+
+    // Enable the PWM
+    pwm->ENABLE = 1;
+
+    // After all of this and many hours of reading the documentation
+    // we are ready to start the sequence...
+    pwm->EVENTS_SEQEND[0]  = 0;
+    pwm->TASKS_SEQSTART[0] = 1;
+
+    // But we have to wait for the flag to be set.
+    while(!pwm->EVENTS_SEQEND[0])
+    {
+      #ifdef ARDUINO_FEATHER52
+      yield();
+      #endif
+    }
+
+    // Before leave we clear the flag for the event.
+    pwm->EVENTS_SEQEND[0] = 0;
+
+    // We need to disable the device and disconnect
+    // all the outputs before leave or the device will not
+    // be selected on the next call.
+    // TODO: Check if disabling the device causes performance issues.
+    pwm->ENABLE = 0;
+
+    pwm->PSEL.OUT[0] = 0xFFFFFFFFUL;
+
+    #ifdef ARDUINO_FEATHER52  // use thread-safe free
+      rtos_free(pixels_pattern);
+    #else
+      free(pixels_pattern);
+    #endif
+  }// End of DMA implementation
+  // ---------------------------------------------------------------------
+  else{
+    // Fall back to DWT
+    #ifdef ARDUINO_FEATHER52
+      // Bluefruit Feather 52 uses freeRTOS
+      // Critical Section is used since it does not block SoftDevice execution
+      taskENTER_CRITICAL();
+    #elif defined(NRF52_DISABLE_INT)
+      // If you are using the Bluetooth SoftDevice we advise you to not disable
+      // the interrupts. Disabling the interrupts even for short periods of time
+      // causes the SoftDevice to stop working.
+      // Disable the interrupts only in cases where you need high performance for
+      // the LEDs and if you are not using the EasyDMA feature.
+      __disable_irq();
+    #endif
+
+    uint32_t pinMask = 1UL << NRF_GPIO_PIN_MAP(PIN_MAP2[pin].gpio_port, PIN_MAP2[pin].gpio_pin);
+
+
+    uint32_t CYCLES_X00     = CYCLES_800;
+    uint32_t CYCLES_X00_T1H = CYCLES_800_T1H;
+    uint32_t CYCLES_X00_T0H = CYCLES_800_T0H;
+
+#ifdef NEO_KHZ400
+    if( !is800KHz )
+    {
+      CYCLES_X00     = CYCLES_400;
+      CYCLES_X00_T1H = CYCLES_400_T1H;
+      CYCLES_X00_T0H = CYCLES_400_T0H;
+    }
+#endif
+
+    // Enable DWT in debug core
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    // Tries to re-send the frame if is interrupted by the SoftDevice.
+    while(1) {
+      uint8_t *p = pixels;
+
+      uint32_t cycStart = DWT->CYCCNT;
+      uint32_t cyc = 0;
+
+      for(uint16_t n=0; n<numBytes; n++) {
+        uint8_t pix = *p++;
+
+        for(uint8_t mask = 0x80; mask; mask >>= 1) {
+          while(DWT->CYCCNT - cyc < CYCLES_X00);
+          cyc  = DWT->CYCCNT;
+
+          NRF_GPIO->OUTSET |= pinMask;
+
+          if(pix & mask) {
+            while(DWT->CYCCNT - cyc < CYCLES_X00_T1H);
+          } else {
+            while(DWT->CYCCNT - cyc < CYCLES_X00_T0H);
+          }
+
+          NRF_GPIO->OUTCLR |= pinMask;
+        }
+      }
+      while(DWT->CYCCNT - cyc < CYCLES_X00);
+
+
+      // If total time longer than 25%, resend the whole data.
+      // Since we are likely to be interrupted by SoftDevice
+      if ( (DWT->CYCCNT - cycStart) < ( 8*numBytes*((CYCLES_X00*5)/4) ) ) {
+        break;
+      }
+
+      // re-send need 300us delay
+      delayMicroseconds(300);
+    }
+
+    // Enable interrupts again
+    #ifdef ARDUINO_FEATHER52
+      taskEXIT_CRITICAL();
+    #elif defined(NRF52_DISABLE_INT)
+      __enable_irq();
+    #endif
+  }
+// END of NRF52 implementation
+
+
+#endif
   endTime = micros(); // Save EOD time for latch on next call
 }
 


### PR DESCRIPTION
I adapted this from the work done here: https://github.com/adafruit/Adafruit_NeoPixel/pull/133

The type system in the current version of adafruit/Adafruit_NeoPixel is different than the current version of this library.  I _think_ everything is compatible since I don't see any mention of type system in the NRF code.

- [x] Test WS2813 on Xenon
- [ ] Test WS2813 on Photon
- [ ] Test WS2812 on Xenon
- [ ] Test WS2812 on Photon
- [x] Test WS2812B on Xenon
- [ ] Test WS2812B on Photon
- [ ] Test WS2811 on Xenon
- [ ] Test WS2811 on Photon
- [ ] Test SK6812RGBW on Xenon
- [ ] Test SK6812RGBW on Photon
- [ ] (Optional) Test Radio Shack TM1803 on Xenon
- [ ] (Optional) Test Radio Shack TM1803 on Photon