### PR TITLE
Add getType() and getPin()

### DIFF
--- a/src/neopixel.cpp
+++ b/src/neopixel.cpp
@@ -85,6 +85,14 @@ Adafruit_NeoPixel::~Adafruit_NeoPixel() {
   if (begun) pinMode(pin, INPUT);
 }
 
+uint8_t Adafruit_NeoPixel::getPin() const {
+    return pin;
+}
+
+uint8_t Adafruit_NeoPixel::getType() const {
+    return type;
+}
+
 void Adafruit_NeoPixel::updateLength(uint16_t n) {
   if (pixels) free(pixels); // Free existing data (if any)
 

--- a/src/neopixel.h
+++ b/src/neopixel.h
@@ -94,7 +94,9 @@ class Adafruit_NeoPixel {
     clear(void);
   uint8_t
    *getPixels() const,
-    getBrightness(void) const;
+    getBrightness(void) const,
+    getPin() const,
+    getType() const;
   uint16_t
     numPixels(void) const,
     getNumLeds(void) const;


### PR DESCRIPTION
This is useful if you need to copy or recreate a `Adafruit_NeoPixel` e.g.

```
Adafruit_NeoPixel strip(150, A1, WS2812B);
Adafruit_NeoPixel strip2(50, strip.getPin(), strip.getType());
```